### PR TITLE
Call template with nice fetch method

### DIFF
--- a/ps_searchbar.php
+++ b/ps_searchbar.php
@@ -77,7 +77,7 @@ class Ps_Searchbar extends Module implements WidgetInterface
     {
         $this->smarty->assign($this->getWidgetVariables($hookName, $configuration));
 
-        return $this->display(__FILE__, 'ps_searchbar.tpl');
+        return $this->fetch('module:ps_searchbar/ps_searchbar.tpl');
     }
 
     public function hookHeader()


### PR DESCRIPTION
`$this->display()` should not be used anymore!

Have a look at this: https://github.com/PrestaShop/PrestaShop/pull/6491