### PR TITLE
Fix mixed content on non-SSL pages

### DIFF
--- a/ps_searchbar.js
+++ b/ps_searchbar.js
@@ -18,7 +18,7 @@ $(document).ready(function () {
 
     $searchBox.psBlockSearchAutocomplete({
         source: function (query, response) {
-            $.get(searchURL, {
+            $.post(searchURL, {
                 s: query.term,
                 resultsPerPage: 10
             }, null, 'json')

--- a/ps_searchbar.php
+++ b/ps_searchbar.php
@@ -69,7 +69,7 @@ class Ps_Searchbar extends Module implements WidgetInterface
     public function getWidgetVariables($hookName, array $configuration = [])
     {
         $widgetVariables = array(
-            'search_controller_url' => $this->context->link->getPageLink('search'),
+            'search_controller_url' => $this->context->link->getPageLink('search', null, null, null, false, null, true),
         );
 
         if (!array_key_exists('search_string', $this->context->smarty->getTemplateVars())) {


### PR DESCRIPTION
This PR fixes an issue when we enable SSL mode on PrestaShop.
To reproduce the error, go on the account page, and try to make a search with the autocomplete feature.

Related issue: http://forge.prestashop.com/browse/BOOM-2644