### PR TITLE
Add upgrade script to clean a file from classic core theme

### DIFF
--- a/upgrade/upgrade-2.1.2.php
+++ b/upgrade/upgrade-2.1.2.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ */
+
+// In the latest version PrestaShop 1.7.8 the override for this module in classic theme was removed
+// because the module is now self-sufficient, so we remove it from the theme to make sure the correct
+// internal template is used (we only clean the theme from core classic theme, and only if it was not
+// updated). Since this version of the module is only compatible starting PS 1.7.8 this clean can always
+// be performed regardless of the current PrestaShop version.
+// We check that the file matches the latest MD5 from this PR https://github.com/PrestaShop/PrestaShop/pull/22032
+// when it was removed
+
+if (defined('_PS_ROOT_DIR_')) {
+    $coreThemeFileChecksum = 'a37c4a845628588260b776d747905b0a';
+    $coreThemeFile = realpath(_PS_ROOT_DIR_ . '/themes/classic/modules/ps_searchbar/ps_searchbar.tpl');
+    if (file_exists($coreThemeFile) && md5_file($coreThemeFile) === $coreThemeFileChecksum) {
+        @unlink($coreThemeFile);
+    }
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In PrestaShop version 1.7.8 an override template has been removed in the classic theme. During the update process, the remaining files are not deleted, but if this file is still present it breaks the integration of the new module so it needs to remove it internally during its own upgrade process.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/25594
| How to test?  | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
