### PR TITLE
Fix jQuery event shorthand is deprecated

### DIFF
--- a/ps_searchbar.js
+++ b/ps_searchbar.js
@@ -47,19 +47,19 @@ $(document).ready(function () {
         },
     }).psBlockSearchAutocomplete("widget").addClass('searchbar-autocomplete');
 
-    $(window).resize(function() {
+    $(window).on("resize", function() {
       $searchBox.psBlockSearchAutocomplete({
         position: autocompletePosition(),
       });
-      $searchBox.keyup();
+      $searchBox.trigger("keyup");
     });
 
-    $clearButton.click(function() {
+    $clearButton.on("click", function() {
         $searchBox.val("");
         $clearButton.hide();
     });
 
-    $searchBox.keyup(function() {
+    $searchBox.on("keyup", function() {
         $clearButton.toggle($searchBox.val() !== "" && isMobile());
     });
 });


### PR DESCRIPTION

![PS1 7 8 5_ps_searchbar_event_shorthand_deprecated](https://user-images.githubusercontent.com/3759923/175469568-dae8ee19-7ad0-4ed8-964c-766c11e9113b.png)
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | resize, click, and keyup event shorthand are deprecated in jQuery 3. jquery-migrate keep warnings about them before fix automatically.
| Type?         | improvement
| BC breaks?    | yes
| Deprecations? | yes
| Fixed ticket? | Fixes PrestaShop/Prestashop#{issue number here}.
| How to test?  | Open Home page and check web browser console before and after apply PR. Don't forget to clear your browser cache after apply PR.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
